### PR TITLE
Adding stripPropTypes function

### DIFF
--- a/bin/shapeshifter.js
+++ b/bin/shapeshifter.js
@@ -20,6 +20,7 @@ shapeshifter
   .option('--schemas', 'Include schema class exports in the output. Defaults to false.')
   .option('--attributes', 'Include an attribute list in the schema class export. Defaults to false.')
   .option('--types', 'Include type definition exports in the output. Defaults to false.')
+  .option('--stripPropTypes', 'Strip PropTypes shapes in production. Defaults to false.')
   .action(function({ options, source }) {
     return new Transpiler({
       compact: options.compact || false,
@@ -29,6 +30,7 @@ shapeshifter
       includeTypes: options.types || false,
       indentCharacter: options.indent || '  ',
       renderer: options.format || 'react',
+      stripPropTypes: options.stripPropTypes || false,
     })
       .transpile(path.normalize(path.join(process.cwd(), source)))
       .then((output) => {

--- a/src/renderers/React.js
+++ b/src/renderers/React.js
@@ -29,13 +29,19 @@ export default class ReactRenderer extends Renderer {
 
   beforeParse() {
     this.imports.push('import PropTypes from \'prop-types\';');
-    this.header.push('const __productionShape__ = () => {}');
+    if (this.options.stripPropTypes) {
+      this.header.push('const __productionShape__ = () => {}');
+    }
   }
 
   render(setName: string, attributes: Definition[] = []) {
     const shape = this.formatObject(this.renderObjectProps(attributes, 1), 0);
 
-    return `export const ${setName} = process.env.NODE_ENV === 'production' ? __productionShape__ : PropTypes.shape(${shape});`;
+    if (this.options.stripPropTypes) {
+      return `export const ${setName} = process.env.NODE_ENV === 'production' ? __productionShape__ : PropTypes.shape(${shape});`;
+    }
+
+    return `export const ${setName} = PropTypes.shape(${shape});`;
   }
 
   renderArray(definition: ArrayDefinition, depth: number): string {

--- a/src/renderers/React.js
+++ b/src/renderers/React.js
@@ -29,12 +29,13 @@ export default class ReactRenderer extends Renderer {
 
   beforeParse() {
     this.imports.push('import PropTypes from \'prop-types\';');
+    this.header.push('const __productionShape__ = () => {}');
   }
 
   render(setName: string, attributes: Definition[] = []) {
     const shape = this.formatObject(this.renderObjectProps(attributes, 1), 0);
 
-    return `export const ${setName} = PropTypes.shape(${shape});`;
+    return `export const ${setName} = process.env.NODE_ENV === 'production' ? __productionShape__ : PropTypes.shape(${shape});`;
   }
 
   renderArray(definition: ArrayDefinition, depth: number): string {

--- a/src/types.js
+++ b/src/types.js
@@ -16,6 +16,7 @@ export type Options = {
   includeTypes: boolean,
   indentCharacter: string,
   renderer: string,
+  stripPropTypes: boolean,
 };
 
 export type PrimitiveType = string | number | boolean;

--- a/tests/renderers/React.test.js
+++ b/tests/renderers/React.test.js
@@ -27,6 +27,17 @@ describe('ReactRenderer', () => {
 
       expect(renderer.imports).toEqual(['import PropTypes from \'prop-types\';']);
     });
+
+    it('adds production noop when stripPropTypes is true', () => {
+      const prodRenderer = new ReactRenderer({ ...options, stripPropTypes: true }, new Schematic('./foo.json', {
+        name: 'Foo',
+        attributes: { id: 'number' },
+      }, options));
+
+      prodRenderer.beforeParse();
+
+      expect(prodRenderer.header).toEqual(['const __productionShape__ = () => {}']);
+    });
   });
 
   describe('renderArray()', () => {


### PR DESCRIPTION
This adds a new CLI flag `--stripPropTypes` to replace `PropTypes.shape()` calls with `process.env.NODE_ENV === 'production' ? noop : PropTypes.Shape()`. This allows minifiers to remove all of the PropType shapes, without breaking imports.

PropTypes already strips the checkers in prod, but this helps us keep size down, as we'll stop shipping a bunch of key/value noop pairs to prod. In our codebase, this dropped the min/gzip size of our schema file from 6.62kb to 1.96kb.