### PR TITLE
fix: replace __DEV__ with NODE_ENV check

### DIFF
--- a/packages/core/src/Schema.ts
+++ b/packages/core/src/Schema.ts
@@ -76,7 +76,7 @@ export default class Schema<T = unknown> {
     relation: string,
     polymorph?: PolymorphRelation,
   ): this {
-    if (__DEV__) {
+    if ("production" !== process.env.NODE_ENV) {
       if (!(schema instanceof Schema)) {
         throw new TypeError(`Relation "${attribute}" is not a valid schema.`);
       } else if (this.relationTypes[attribute] && this.relationTypes[attribute] !== relation) {

--- a/packages/core/src/Schema.ts
+++ b/packages/core/src/Schema.ts
@@ -76,7 +76,7 @@ export default class Schema<T = unknown> {
     relation: string,
     polymorph?: PolymorphRelation,
   ): this {
-    if ("production" !== process.env.NODE_ENV) {
+    if (process.env.NODE_ENV !== 'production') {
       if (!(schema instanceof Schema)) {
         throw new TypeError(`Relation "${attribute}" is not a valid schema.`);
       } else if (this.relationTypes[attribute] && this.relationTypes[attribute] !== relation) {

--- a/packages/core/types/global.d.ts
+++ b/packages/core/types/global.d.ts
@@ -1,1 +1,0 @@
-declare const __DEV__: boolean;


### PR DESCRIPTION
We were attempting to use code that depends on shapeshifter in an environment that doesn't understand `__DEV__`.

Looks like the `__DEV__` construct originated as an FBism. Though the React build results in code that doesn't rely `__DEV__`.
https://overreacted.io/how-does-the-development-mode-work/

Since `NODE_ENV` checks are more standard, it seemed fair to update shapeshifter to not export the assumption of running in an environment that understands `__DEV__`.

I also looked into packaging this with packemon (like https://github.com/milesj/interweave/pull/144/). But, that seemed like a much more involved change just to update one usage, especially since this package is considered deprecated based on the README.

Reviewer: @milesj 

cc @rsolomon